### PR TITLE
ci: reduce dependabot PR noise with groups and cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,21 @@ updates:
       - "rust"
     commit-message:
       prefix: "ci(rust)"
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      development-dependencies:
+        dependency-type: "development"
+        applies-to: version-updates
+      production-minor:
+        dependency-type: "production"
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -20,6 +35,11 @@ updates:
       - "python"
     commit-message:
       prefix: "ci(python)"
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       dev-dependencies:
         patterns:
@@ -35,6 +55,21 @@ updates:
       - "node"
     commit-message:
       prefix: "ci(node)"
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      development-dependencies:
+        dependency-type: "development"
+        applies-to: version-updates
+      production-minor:
+        dependency-type: "production"
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -42,3 +77,13 @@ updates:
     open-pull-requests-limit: 100
     commit-message:
       prefix: ci
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      actions:
+        patterns:
+          - "*"
+        applies-to: version-updates


### PR DESCRIPTION
## Summary

Dependabot is currently opening ~20 individual PRs per update cycle, creating significant maintenance overhead. This adds:

- **Dependency groups** — batches related updates into fewer PRs (dev deps together, production minor+patch together, all GH Actions together)
- **Cooldown periods** — rate-limits how frequently new version-update PRs are opened (major: 30d, minor: 7d, patch: 3d)

Expected reduction: **~20 PRs → ~7 PRs per cycle** (~65% fewer).

Security updates are unaffected — they bypass cooldown and grouping, so CVE patches still get immediate, dedicated PRs.

Follows the same pattern used in [strands-agents/harness-sdk](https://github.com/strands-agents/harness-sdk/blob/main/.github/dependabot.yml).

## Test plan

- [ ] Verify dependabot picks up the new config on next scheduled run
- [ ] Confirm grouped PRs appear (e.g. "ci(rust): bump the production-minor group")
- [ ] Confirm security advisories still get immediate standalone PRs