### PR TITLE
chore: update documentation urls to latest paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,5 +163,5 @@ PR titles must follow [Conventional Commits](https://www.conventionalcommits.org
 - [CONTRIBUTING.md](./CONTRIBUTING.md) — human contributor guidelines, full development environment setup
 - [SECURITY.md](./SECURITY.md) — vulnerability reporting
 - [README.md](./README.md) — product overview, configuration, supported commands
-- [Command Reference](https://strandsagents.com/docs/user-guide/shell-sdk/commands/) — per-command status and known gaps
+- [Command Reference](https://strandsagents.com/docs/user-guide/shell/commands/) — per-command status and known gaps
 - [Strands Agents Documentation](https://strandsagents.com/)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   </div>
 
   <p>
-    <a href="https://strandsagents.com/docs/user-guide/shell-sdk/">Documentation</a>
+    <a href="https://strandsagents.com/docs/user-guide/shell/">Documentation</a>
     ◆ <a href="#mcp-server">MCP Server</a>
     ◆ <a href="#python">Python</a>
     ◆ <a href="#nodejs">Node.js</a>

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Out of the box, the shell is an empty sandbox — no files, no network, no crede
 
 The commands agents use constantly: `grep`, `find`, `cat`, `head`, `tail`, `jq` for reading and searching. `sed`, `sort`, `tr`, `cut` for transforming output. `cp`, `mv`, `rm`, `mkdir` for managing files. `curl` for HTTP (SSRF-guarded, credentials auto-injected). `lua` for scripting when shell gets awkward.
 
-The [full command reference](https://strandsagents.com/docs/user-guide/shell-sdk/commands/) has the inventory with implementation status, supported flags, and known gaps vs GNU coreutils.
+The [full command reference](https://strandsagents.com/docs/user-guide/shell/commands/) has the inventory with implementation status, supported flags, and known gaps vs GNU coreutils.
 
 ## File Operations API
 


### PR DESCRIPTION
## Description

Update the documentation links to use the latest paths following https://github.com/strands-agents/harness-sdk/pull/2860

## Related Issues

https://github.com/strands-agents/harness-sdk/pull/2860


## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
