### PR TITLE
ci: add aggregate CI Gate as the single required status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,3 +146,26 @@ jobs:
 
       - name: npm test
         run: npm test
+
+  # Single required status check. Branch protection can require just this one
+  # context ("CI Gate") instead of every matrix leg (Rust/Python/Node/audit),
+  # whose names change whenever the matrix changes. This job fails if any
+  # needed job failed or was cancelled, so it is a faithful aggregate gate.
+  gate:
+    name: CI Gate
+    if: always()
+    needs: [rust, python, audit, node]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "Needed job results: $RESULTS"
+          for result in $RESULTS; do
+            if [ "$result" != "success" ]; then
+              echo "::error::A required CI job did not succeed (result: $result)."
+              exit 1
+            fi
+          done
+          echo "All required CI jobs succeeded."


### PR DESCRIPTION
## Description

Works toward #32 ("Run tests on PRs and require to pass before merging").

The first box of #32 — *workflows that run on PRs* — is **already done**: `ci.yml` runs the Rust, Python, Node, and security-audit jobs on every PR, and `pr-title.yml` validates the title. The remaining gap is the second box: **the checks aren't *required* before merge.**

This PR makes requiring them robust.

### The problem with requiring the matrix legs directly

The CI matrix expands to ~30 dynamically-named check runs, e.g.:

```
Rust (ubuntu-latest)            Python (ubuntu-latest, 3.14)
Rust (macos-latest)             Node.js (macos-latest, Node 22)
Security audit                  ... (and ~25 more)
```

Marking each of these as a required status check in branch protection is brittle — every time the Python/Node version matrix changes, the required-checks list silently drifts, and a whole leg can be dropped from the gate without anyone noticing.

### The fix

Add a single **`CI Gate`** job that `needs: [rust, python, audit, node]` and fails unless *every* needed job succeeded. It uses `if: always()` + `join(needs.*.result, ' ')` so it also catches **cancelled** jobs, not just failures.

Branch protection then only needs to require the one stable context **`CI Gate`**, which stays correct as the matrix evolves.

### Admin follow-up required (cannot be done in a PR)

Requiring the check is a repo *setting*, not a file. A maintainer needs to enable it. The repo already has a **disabled** ruleset named **`main-only rules`** targeting `main` that enforces reviews but has **no status-check rule**. Recommended: enable that ruleset and add a `required_status_checks` rule for context `CI Gate` (integration: GitHub Actions). I've left the exact API/UI steps on #32.

### Testing

- `python -c "import yaml; yaml.safe_load(...)"` parses cleanly; 5 jobs present with correct `needs`.
- `actionlint .github/workflows/ci.yml` → clean.
- The gate job itself will run on this PR — its result is the proof.

### Notes for the reviewer

- One-file change (`.github/workflows/ci.yml`); no behavior change to the existing jobs.
- `audit` is intentionally included in the gate (it builds + runs `npm audit --omit=dev`; the RustSec `cargo audit` step is `continue-on-error` so the job still passes while advisories are triaged).

PR title follows Conventional Commits (`ci:`).