### PR TITLE
feat: add Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,13 @@ jobs:
         shell: bash
         run: |
           python -m venv .venv
+          # GITHUB_PATH entries must be native paths. In Git Bash on Windows
+          # $PWD is an MSYS path (/d/a/shell/shell) that the runner's Windows
+          # PATH cannot resolve, so the venv would be silently ignored and
+          # later steps would fall back to the host interpreter. Convert to a
+          # native Windows path with cygpath so .venv\Scripts is actually used.
           if [ "$RUNNER_OS" == "Windows" ]; then
-            echo "$PWD/.venv/Scripts" >> "$GITHUB_PATH"
+            cygpath -w "$PWD/.venv/Scripts" >> "$GITHUB_PATH"
           else
             echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -62,17 +62,27 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      # Create the venv and put its bin/Scripts dir on PATH so the
+      # subsequent steps work identically on Unix (.venv/bin) and
+      # Windows (.venv/Scripts).
       - name: Create virtualenv
-        run: python -m venv .venv
+        shell: bash
+        run: |
+          python -m venv .venv
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            echo "$PWD/.venv/Scripts" >> "$GITHUB_PATH"
+          else
+            echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+          fi
 
       - name: Install build deps
-        run: .venv/bin/pip install maturin pytest
+        run: pip install maturin pytest
 
       - name: Build and install wheel
-        run: .venv/bin/maturin develop --release
+        run: maturin develop --release
 
       - name: pytest
-        run: .venv/bin/pytest tests/python -v
+        run: pytest tests/python -v
 
   audit:
     name: Security audit
@@ -115,7 +125,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         node: ["20", "22", "24"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -133,6 +143,15 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
+
+      # The package.json build scripts use `$(npm run --silent host-triple)`
+      # command substitution. npm runs script bodies with its configured
+      # script-shell, which defaults to cmd.exe on Windows (no `$(...)`
+      # support). Point it at the Git Bash that ships on the windows-latest
+      # runner so the substitution works identically across platforms.
+      - name: Use bash as npm script-shell (Windows)
+        if: runner.os == 'Windows'
+        run: npm config set script-shell bash
 
       - name: npm install
         # package-lock.json is gitignored, so `npm ci` can't run; use install.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,9 +290,9 @@ jobs:
             native.js
             native.d.ts
 
-  # ── Pack all 5 npm packages (fan-in from the per-platform builds) ─────────
+  # ── Pack all 6 npm packages (fan-in from the per-platform builds) ─────────
   # Assembles the exact publishable set — the main @strands-agents/shell package
-  # plus the 4 per-platform packages — using the napi-rs v3 release flow, then
+  # plus the 5 per-platform packages — using the napi-rs v3 release flow, then
   # packs each to a .tgz and uploads them. Download the `npm-packages` artifact
   # to install/test the real tarballs locally before any publish happens.
   node-pack:
@@ -351,8 +351,8 @@ jobs:
           for d in npm/*/; do (cd "$d" && npm pack --pack-destination "$GITHUB_WORKSPACE/dist-npm"); done
 
       - name: Verify the packaged set matches the publish matrix
-        # Guard against drift: the publish stage uses a static matrix of the 4
-        # platform packages (+ the main package = 5 total). If package.json's
+        # Guard against drift: the publish stage uses a static matrix of the 5
+        # platform packages (+ the main package = 6 total). If package.json's
         # napi.targets gains/loses a target, the packed count changes here and
         # this fails the run BEFORE anything is published — prompting whoever
         # changed the targets to update node-publish-platform's matrix to match.
@@ -379,7 +379,7 @@ jobs:
           name: npm-packages
           path: dist-npm/*.tgz
 
-  # ── Publish the 4 per-platform packages (one independently retriable job each)
+  # ── Publish the 5 per-platform packages (one independently retriable job each)
   # Each leg publishes exactly one tarball that node-inspect packed + uploaded,
   # so a flaky single platform can be re-run on its own via "Re-run failed jobs"
   # without touching the others. The matrix is static — its entries must match

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,8 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             manylinux: "2_28"
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -158,7 +160,7 @@ jobs:
           set -euo pipefail
           echo "Dists:"; ls -1 dist/
           missing=()
-          for target in aarch64-apple-darwin x86_64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu; do
+          for target in aarch64-apple-darwin x86_64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-pc-windows-msvc; do
             # Maturin encodes the target in the wheel filename's platform tag:
             #   aarch64-apple-darwin   → macosx_*_arm64
             #   x86_64-apple-darwin    → macosx_*_x86_64
@@ -169,6 +171,7 @@ jobs:
               x86_64-apple-darwin)        pattern="macosx_*_x86_64" ;;
               x86_64-unknown-linux-gnu)   pattern="manylinux_*_x86_64" ;;
               aarch64-unknown-linux-gnu)  pattern="manylinux_*_aarch64" ;;
+              x86_64-pc-windows-msvc)     pattern="win_amd64" ;;
             esac
             if ! ls dist/*${pattern}*.whl >/dev/null 2>&1; then
               missing+=("$target")
@@ -228,6 +231,8 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -353,11 +358,11 @@ jobs:
         # changed the targets to update node-publish-platform's matrix to match.
         run: |
           set -euo pipefail
-          expected=5
+          expected=6
           actual=$(ls dist-npm/*.tgz | wc -l | tr -d ' ')
           echo "Packed tarballs ($actual):"; ls -1 dist-npm/*.tgz
           if [ "$actual" -ne "$expected" ]; then
-            echo "::error::Expected $expected npm packages (1 main + 4 platform) but packed $actual. If napi.targets changed, update node-publish-platform's matrix to match."
+            echo "::error::Expected $expected npm packages (1 main + 5 platform) but packed $actual. If napi.targets changed, update node-publish-platform's matrix to match."
             exit 1
           fi
 
@@ -401,6 +406,7 @@ jobs:
           - strands-agents-shell-darwin-arm64
           - strands-agents-shell-linux-x64-gnu
           - strands-agents-shell-linux-arm64-gnu
+          - strands-agents-shell-win32-x64-msvc
     env:
       V: ${{ needs.version.outputs.version }}
     steps:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
       "x86_64-apple-darwin",
       "aarch64-apple-darwin",
       "x86_64-unknown-linux-gnu",
-      "aarch64-unknown-linux-gnu"
+      "aarch64-unknown-linux-gnu",
+      "x86_64-pc-windows-msvc"
     ]
   },
   "engines": {

--- a/src/vfs_kernel.rs
+++ b/src/vfs_kernel.rs
@@ -121,20 +121,35 @@ impl VfsKernel {
         canon_base: &std::path::Path,
     ) -> io::Result<Fd> {
         if flags.read && !flags.write {
-            // Open the file, then verify via /proc/self/fd that the
-            // opened fd still points within the bind mount. This
-            // eliminates the TOCTOU between canonicalize and read.
             let file = std::fs::File::open(host_path)?;
-            use std::os::unix::io::AsRawFd;
-            let fd_path = format!("/proc/self/fd/{}", file.as_raw_fd());
-            if let Ok(real) = std::fs::read_link(&fd_path)
-                && !real.starts_with(canon_base)
+
+            // Defense-in-depth TOCTOU check: after opening, verify via
+            // /proc/self/fd that the opened fd still points within the bind
+            // mount. This closes the race between canonicalize() and open().
+            //
+            // This is Linux-only: /proc/self/fd is a Linux procfs interface
+            // with no portable equivalent (macOS has no /proc; Windows has no
+            // procfs at all). On other platforms the canonical-path check
+            // performed before this function is called is the primary security
+            // boundary, so we simply skip this extra verification there.
+            #[cfg(target_os = "linux")]
             {
-                return Err(io::Error::new(
-                    io::ErrorKind::PermissionDenied,
-                    "access denied: path escaped bind mount",
-                ));
+                use std::os::unix::io::AsRawFd;
+                let fd_path = format!("/proc/self/fd/{}", file.as_raw_fd());
+                if let Ok(real) = std::fs::read_link(&fd_path)
+                    && !real.starts_with(canon_base)
+                {
+                    return Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        "access denied: path escaped bind mount",
+                    ));
+                }
             }
+            // `canon_base` is only consumed by the Linux-only check above; on
+            // other targets it is intentionally unused.
+            #[cfg(not(target_os = "linux"))]
+            let _ = canon_base;
+
             use std::io::Read;
             let mut data = Vec::new();
             let mut file = file;

--- a/src/vfs_kernel.rs
+++ b/src/vfs_kernel.rs
@@ -123,15 +123,9 @@ impl VfsKernel {
         if flags.read && !flags.write {
             let file = std::fs::File::open(host_path)?;
 
-            // Defense-in-depth TOCTOU check: after opening, verify via
-            // /proc/self/fd that the opened fd still points within the bind
-            // mount. This closes the race between canonicalize() and open().
-            //
-            // This is Linux-only: /proc/self/fd is a Linux procfs interface
-            // with no portable equivalent (macOS has no /proc; Windows has no
-            // procfs at all). On other platforms the canonical-path check
-            // performed before this function is called is the primary security
-            // boundary, so we simply skip this extra verification there.
+            // Defense-in-depth TOCTOU re-check (Linux-only): /proc/self/fd has
+            // no portable equivalent, and the canonical-path check above is the
+            // primary guard, so this extra layer is simply skipped elsewhere.
             #[cfg(target_os = "linux")]
             {
                 use std::os::unix::io::AsRawFd;
@@ -145,10 +139,8 @@ impl VfsKernel {
                     ));
                 }
             }
-            // `canon_base` is only consumed by the Linux-only check above; on
-            // other targets it is intentionally unused.
             #[cfg(not(target_os = "linux"))]
-            let _ = canon_base;
+            let _ = canon_base; // only consumed by the Linux-only check above
 
             use std::io::Read;
             let mut data = Vec::new();

--- a/tests/shell_integration.rs
+++ b/tests/shell_integration.rs
@@ -5352,7 +5352,7 @@ umask = "077"
 
 [[bind]]
 mode = "copy"
-source = "{}"
+source = '{}'
 destination = "/workspace"
 readonly = true
 

--- a/tests/shell_integration.rs
+++ b/tests/shell_integration.rs
@@ -4277,6 +4277,9 @@ fn builder_bind_direct_readonly_host() {
     }));
 }
 
+// Uses std::os::unix::fs::symlink — symlink creation differs on Windows
+// (requires elevated privileges), so this escape test is Unix-only.
+#[cfg(unix)]
 #[test]
 fn bind_direct_symlink_escape_blocked() {
     let (rt, local) = rt();
@@ -7381,6 +7384,9 @@ expect!(cmd_sleep_zero, "command sleep 0 && echo ok", "ok");
 
 // ── dangling symlink escape prevention ──────────────────────────────
 
+// Uses std::os::unix::fs::symlink — symlink creation differs on Windows
+// (requires elevated privileges), so this escape test is Unix-only.
+#[cfg(unix)]
 #[test]
 fn bind_direct_dangling_symlink_blocked() {
     let (rt, local) = rt();


### PR DESCRIPTION
## Summary

Makes Strands Shell build, test, and ship on Windows. Closes the gap identified in the linked research: the crate didn't compile on Windows out of the box.

The **only** non-portable code in the library was a single Linux-only TOCTOU check in the host-file read path. Everything else was already cleanly `#[cfg]`-gated.

## Root cause

`src/vfs_kernel.rs::open_host()` (read branch) unconditionally used `std::os::unix::io::AsRawFd` + `/proc/self/fd/<fd>` to re-verify, after `open()`, that the opened fd still pointed inside the bind mount. This:
- doesn't exist on Windows (`std::os::unix` is absent → `E0433`/`E0599`), and
- never actually functioned on macOS either (no `/proc`), it just happened to compile there because macOS has the `std::os::unix` module.

## Changes

### Core fix — `src/vfs_kernel.rs`
- Gate the `/proc/self/fd` defense-in-depth TOCTOU verification behind `#[cfg(target_os = "linux")]`. This is purely a Linux procfs interface, so the check only ever ran on Linux. **The primary security boundary is unchanged**: the canonical-path containment check performed before `open_host()` still runs on every platform. This narrows the platform of an *extra* defense layer rather than weakening Linux's guarantee.
- `canon_base` is now only consumed by that Linux-only block, so it's explicitly marked unused on other targets (no warnings).

### Tests — `tests/shell_integration.rs`
- Gate `bind_direct_symlink_escape_blocked` and `bind_direct_dangling_symlink_blocked` behind `#[cfg(unix)]`. They call `std::os::unix::fs::symlink`, which doesn't exist on Windows (and symlink creation there needs elevated privileges). They continue to run on Linux/macOS.

### CI — `.github/workflows/ci.yml`
- Add `windows-latest` to the **rust**, **python**, and **node** matrices.
- Make the python job cross-platform: build the venv and add its `bin`/`Scripts` dir to `GITHUB_PATH` instead of hardcoding `.venv/bin`.
- On Windows, set npm `script-shell` to `bash` so `package.json`'s `$(npm run --silent host-triple)` command substitution works (npm defaults to `cmd.exe` there).

### CD — `.github/workflows/release.yml`, `package.json`
- Add `x86_64-pc-windows-msvc` to: the Python wheel matrix, the Node addon matrix, `napi.targets`, and the publish-platform matrix (new `strands-agents-shell-win32-x64-msvc` package).
- Update the inspect coverage check (`win_amd64` wheel) and bump the npm pack count guard `5 → 6`.

## Validation

- ✅ Cross-compiled **lib + bins + all tests** to `x86_64-pc-windows-gnu` — clean, no warnings.
- ✅ Cross-checked the `python` feature for Windows via `PYO3_CROSS_PYTHON_VERSION`.
- ✅ Full suite green on Linux: **1296 passed**, including both `#[cfg(unix)]`-gated symlink escape tests.
- ⏳ The new `windows-latest` CI legs (native MSVC build of Rust/Python/Node) will be the authoritative cross-platform proof once this PR's CI runs.

> Note: the maintainer asked me to validate on a real Windows host via AWS EC2, but this CI role has no `ec2:*` permissions. GitHub's free `windows-latest` runners are the equivalent (and cheaper) native validation path, which is why I wired them into CI rather than provisioning an instance. Happy to do a manual EC2 run if you'd prefer — just need EC2 access.

---

cc @mkmeral — opened as a draft for your review.