### PR TITLE
ci: bump npm publish jobs to Node 24 (npm@latest EBADENGINE)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -759,7 +759,8 @@ jobs:
       # No checkout/build — publish the exact tarball node-pack uploaded.
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          # npm@latest requires Node >= 22.22.2 / 24.15.0; Node 20 fails EBADENGINE.
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Update npm to latest
@@ -795,7 +796,8 @@ jobs:
     steps:
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          # npm@latest requires Node >= 22.22.2 / 24.15.0; Node 20 fails EBADENGINE.
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Update npm to latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -759,7 +759,6 @@ jobs:
       # No checkout/build — publish the exact tarball node-pack uploaded.
       - uses: actions/setup-node@v6
         with:
-          # npm@latest requires Node >= 22.22.2 / 24.15.0; Node 20 fails EBADENGINE.
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
@@ -796,7 +795,6 @@ jobs:
     steps:
       - uses: actions/setup-node@v6
         with:
-          # npm@latest requires Node >= 22.22.2 / 24.15.0; Node 20 fails EBADENGINE.
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 


### PR DESCRIPTION
## What

Bump `node-version` from `20` to `24` in the two npm publish jobs (`node-publish-platform` and `node-publish-main`) in `release.yml`.

## Why

The publish jobs set up Node 20 and then run `npm install -g npm@latest`. The current `npm@12.0.1` declares `engines: { node: "^22.22.2 || ^24.15.0 || >=26.0.0" }` and dropped Node 20, so every `npm publish` now fails immediately with:

```
npm error code EBADENGINE
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

This broke the npm side of the **0.3.0** release: all 5 `node-publish-platform` matrix jobs failed and `node-publish-main` was skipped. PyPI published fine, so 0.3.0 currently exists on PyPI but npm is still on 0.2.0 (see run [29584633292](https://github.com/strands-agents/shell/actions/runs/29584633292)).

## Change

- `node-publish-platform`: `node-version: "20"` → `"24"`
- `node-publish-main`: `node-version: "20"` → `"24"`

Build/CI jobs are intentionally left on their current Node version. They don't run `npm install -g npm@latest`, so they aren't affected.

## Verification

- **Static:** `release.yml` parses as YAML; bump scoped to the two publish jobs, CI/build jobs still on Node 20.
- **Reproduced fix:** on the exact **Node 24.15.0** this pins, `npm install -g npm@latest` succeeds → **npm 12.0.1** (the version that threw `EBADENGINE` on Node 20). `EXIT: 0`, no engine error. (Note: Node 25 does *not* satisfy `^22.22.2 || ^24.15.0 || >=26.0.0` either, so 24 is the correct pin.)
- **Publish path:** `npm publish --dry-run` under Node 24 on the real 0.3.0 tarballs (incl. `win32-x64-msvc`) runs clean through packaging + integrity + the dry-run registry step. No errors.
- **Not covered:** the OIDC registry upload itself. Final confirmation is a real publish on Node 24 when the 0.3.0 npm side is reconciled after merge.

## After merge

Re-dispatch 0.3.0 to publish `@strands-agents/shell` to npm and reconcile the split-publish state (PyPI + git tag already at 0.3.0).
