### PR TITLE
chore(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,9 +1216,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## What

Bump `quinn-proto` `0.11.14` → `0.11.15` in `Cargo.lock` (lockfile-only, 2-line change).

## Why

`cargo audit` in the CI security-audit job flags:

```
Crate:    quinn-proto  0.11.14
Title:    Remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly
ID:       RUSTSEC-2026-0185   Severity: 7.5 (high)
Solution: Upgrade to >=0.11.15
```

## Does this block the release?

**No.** Two independent reasons:

1. **Not gating.** The `cargo audit` step in `ci.yml` is `continue-on-error: true`, so the `CI / Security audit` job passes and the release proceeds. The red `X` on the run is just the annotation surfacing.
2. **Not in the shipped artifact.** `quinn-proto` is pulled only transitively via `reqwest → quinn → quinn-proto`. `reqwest` is declared `default-features = false` with only `rustls-tls`, so the `http3`/quinn feature is never enabled. `cargo tree -i quinn-proto` returns nothing, and a `strings` scan of the built `_native` library shows no quinn/QUIC transport code (only rustls/ring TLS QUIC-key-schedule symbols, unrelated). It sits in `Cargo.lock` but is never compiled in.

So this is **Cargo.lock hygiene**, not a runtime exposure.

## Verification

`Cargo.lock` now pins `quinn-proto 0.11.15`; no `0.11.14` entries remain. `cargo audit` on this branch:

```
Loaded 1166 security advisories
Scanning Cargo.lock for vulnerabilities (253 crate dependencies)
```

No vulnerabilities reported — RUSTSEC-2026-0185 cleared (previously the only finding).
