### PR TITLE
docs: correct default per-command timeout in README security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Out of the box, the shell is an empty sandbox — no files, no network, no crede
 - **Prefer `mode: "copy"` over `mode: "direct"` for source code.** Copy-on-create isolates the agent from your live files. Use `direct` only for output directories where the agent needs to persist results.
 - **Scope binds narrowly.** Bind `/my/project/src` rather than `/my/project` or `/`. The agent doesn't need your `.git/`, `.env`, or `node_modules/`.
 - **Allowlist URLs explicitly.** Don't use `allowed_urls: ["https://"]` — this disables SSRF protection entirely. List the specific API endpoints the agent needs.
-- **Keep the timeout.** Each command runs under a 30-second per-command timeout by default, which bounds runaway commands out of the box. Set `timeout` to raise or lower it for your agent loop. The no-timeout case applies only when you embed a custom kernel via `with_kernel`.
+- **Rely on adjustable timeouts.** Commands run under an adjustable per-command timeout, defaulting to 30 seconds, which bounds runaway commands out of the box. Set `timeout` to raise or lower it for your agent loop.
 - **Use limits.** Set `max_output` to prevent agents from filling memory with unbounded command output (1MB is a good default).
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Out of the box, the shell is an empty sandbox — no files, no network, no crede
 - **Prefer `mode: "copy"` over `mode: "direct"` for source code.** Copy-on-create isolates the agent from your live files. Use `direct` only for output directories where the agent needs to persist results.
 - **Scope binds narrowly.** Bind `/my/project/src` rather than `/my/project` or `/`. The agent doesn't need your `.git/`, `.env`, or `node_modules/`.
 - **Allowlist URLs explicitly.** Don't use `allowed_urls: ["https://"]` — this disables SSRF protection entirely. List the specific API endpoints the agent needs.
-- **Set timeouts.** The default has no per-command timeout. Set `timeout` to bound runaway commands (30s is reasonable for most agent loops).
+- **Keep the timeout.** Each command runs under a 30-second per-command timeout by default, which bounds runaway commands out of the box. Set `timeout` to raise or lower it for your agent loop. The no-timeout case applies only when you embed a custom kernel via `with_kernel`.
 - **Use limits.** Set `max_output` to prevent agents from filling memory with unbounded command output (1MB is a good default).
 
 ## Commands


### PR DESCRIPTION
The README "Secure Defaults" section said the shell has **no per-command timeout by default** and advised adding 
  one. The source is the opposite.

  **Fix:** the public builder default *is* a 30-second per-command timeout.

  **Verified against source:**
  - `ShellBuilder::default()` sets `timeout: Some(Duration::from_secs(30))` (`src/shell.rs`).
  - Config tests assert the 30s default: `cfg.timeout_secs == Some(30.0)` (`tests/config.rs`), `cfg.timeout == 30.0` 
  (`tests/python/test_config.py`), `cfg.timeout == 30` (`tests/js/test_config.mjs`).
  - `None` (no timeout) only arises via the custom-kernel embedding path `Shell::with_kernel`, which bypasses the builder.

  Docs-only, one line.